### PR TITLE
Migrated from StandardCyborg to twolfson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# katex-screenshot [![Build status](https://travis-ci.org/StandardCyborg/katex-screenshot.svg?branch=master)](https://travis-ci.org/StandardCyborg/katex-screenshot)
+# katex-screenshot [![Build status](https://travis-ci.org/twolfson/katex-screenshot.svg?branch=master)](https://travis-ci.org/twolfson/katex-screenshot)
 
 Convert [KaTeX][] to images via screenshots
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ## Unlicense
 As of Oct 10 2017, Standard Cyborg has released this repository and its contents to the public domain.
 
+As of Aug 28 2020, Standard Cyborg has transferred ownership to Todd Wolfson. This repository and its contents are still released to the public domain.
+
 It has been released under the [UNLICENSE][].
 
 [UNLICENSE]: UNLICENSE

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "katex-screenshot",
   "description": "Convert KaTeX to images via screenshots",
   "version": "1.2.0",
-  "homepage": "https://github.com/StandardCyborg/katex-screenshot",
+  "homepage": "https://github.com/twolfson/katex-screenshot",
   "author": {
     "name": "Todd Wolfson",
     "email": "todd@twolfson.com",
@@ -10,10 +10,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/StandardCyborg/katex-screenshot.git"
+    "url": "git://github.com/twolfson/katex-screenshot.git"
   },
   "bugs": {
-    "url": "https://github.com/StandardCyborg/katex-screenshot/issues"
+    "url": "https://github.com/twolfson/katex-screenshot/issues"
   },
   "bin": {
     "katex-screenshot": "bin/katex-screenshot.js"


### PR DESCRIPTION
Standard Cyborg has requested that we relocate `katex-screenshot` to my personal account. I've gladly done so. This PR reflects those changes. In this PR:

- Updated license
- Updated URLs